### PR TITLE
Added some patches for filepaths for all platforms

### DIFF
--- a/scripts/Cabinet/Cabinet.gml
+++ b/scripts/Cabinet/Cabinet.gml
@@ -27,7 +27,7 @@ function Cabinet(folder_path, extension = ".*", options = undefined) constructor
 			folder_path,
 			extension,
 			/* returnStruct */ false,
-			_force_lowercase,
+			false,
 			/* structValueGenerator */ undefined,
 			/* forceForwardSlash */ true);
 			
@@ -35,7 +35,7 @@ function Cabinet(folder_path, extension = ".*", options = undefined) constructor
 			folder_path,
 			extension,
 			/* returnStruct */ true,
-			_force_lowercase,
+			false,
 			__generateCabinetItem,
 			/* forceForwardSlash */ true);
 	}
@@ -47,6 +47,11 @@ function Cabinet(folder_path, extension = ".*", options = undefined) constructor
 	
 	// gets the CabinetFile corresponding to the provided 'path' if it exists
 	static file = function(path, is_included_file = true) {
+		// This ensures that weird paths are auto resolved, if in case for some reason they are not.
+		path = string_replace_all(path, "/", "\\");
+		path = string_lower(path);
+		path = string_replace_all(path, "\\", "/");
+		path = filename_path(path) + filename_name(path);	
 		var file = flat_map[$ __fixPath(path, is_included_file)];
 		if file == undefined && CABINET_VERBOSE_LOGGING {
 			show_debug_message("Unable to find file:");
@@ -110,7 +115,7 @@ function Cabinet(folder_path, extension = ".*", options = undefined) constructor
 		}
 		
 		// point the flat_map entry at the cabinet file
-		flat_map[$ fullpath] = result;
+		flat_map[$ string_lower(fullpath)] = result;
 		
 		return result;
 	}

--- a/scripts/Cabinet/Cabinet.gml
+++ b/scripts/Cabinet/Cabinet.gml
@@ -51,7 +51,7 @@ function Cabinet(folder_path, extension = ".*", options = undefined) constructor
 		path = string_replace_all(path, "/", "\\");
 		path = string_lower(path);
 		path = string_replace_all(path, "\\", "/");
-		path = filename_path(path) + filename_name(path);	
+		path = string_replace_all(path, " ", "_");
 		var file = flat_map[$ __fixPath(path, is_included_file)];
 		if file == undefined && CABINET_VERBOSE_LOGGING {
 			show_debug_message("Unable to find file:");
@@ -114,8 +114,12 @@ function Cabinet(folder_path, extension = ".*", options = undefined) constructor
 			options.cabinet_file_customizer(result);
 		}
 		
+		// Force lowercase and replace spaces with underline, due to datafile shennanigans
+		fullpath = string_lower(fullpath);
+		fullpath = string_replace_all(fullpath, " ", "_");
+
 		// point the flat_map entry at the cabinet file
-		flat_map[$ string_lower(fullpath)] = result;
+		flat_map[$ fullpath] = result;
 		
 		return result;
 	}

--- a/scripts/gumshoe/gumshoe.gml
+++ b/scripts/gumshoe/gumshoe.gml
@@ -175,7 +175,7 @@ function __gumshoe_struct(_directory, _extension, _match_all_mask, _path_sep, _g
         {
             //Add this matching file to the output array
             var value = _generator ? _generator(_directory, _file, _extension, global.__gumshoe_count) : global.__gumshoe_count;
-            variable_struct_set(_result, _file, value);
+            variable_struct_set(_result, string_lower(_file), value);
             ++global.__gumshoe_count;
         }
     }

--- a/scripts/yui_load_resource_file/yui_load_resource_file.gml
+++ b/scripts/yui_load_resource_file/yui_load_resource_file.gml
@@ -16,7 +16,8 @@ function yui_load_resource_file(filepath, cabinet, base_folder) {
 		// get the list of files in the folder
 		var filepaths = gumshoe(resource_filepath, cabinet.extension, false);
 		var i = 0; repeat array_length(filepaths) {
-			filepaths[i] = string_delete(yui_string_after(filepaths[i], resource_filepath), 1, 1);
+			// Using the string_length is all we need to trim the resource_filepath
+			filepaths[i] = string_delete(filepaths[i], 1, string_length(resource_filepath));
 			i++;
 		}
 		


### PR DESCRIPTION
This addresses some issues on Linux (and other OSes with filesystems that can be case sensitive), where filepaths aren't respected properly. This also looks to resolve how filepaths slashes are handled, by ensuring that all filepaths have the exact same slash for the string result. GameMaker automatically handles slashes when it comes to files, so this is something that could likely be dropped. And finally ensures that filepaths all have spaces filled out with underlines, to respect how Linux (and perhaps other platforms) would prefer it.

The result of this PR would turn strings like `S:\Git Projects\YUI\datafiles\Blah` into `s:/git_projects/yui/datafiles/blah`  to keep consistent with struct lookups. (This is more important for non-exe scenarios)